### PR TITLE
Add score config variable and check it with the response score of the google response

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -11,7 +11,8 @@ component {
 			apiUrl    = 'https://www.google.com/recaptcha/api/siteverify',
 			scriptUrl = 'https://www.google.com/recaptcha/api.js',
 			secretKey = "",
-			publicKey = ""
+			publicKey = "",
+			score     = 0.5
 		};
 	}
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ moduleSettings = {
 	recaptcha3 = {
     	secretKey 	= "Secret key",
     	publickey 	= "Site key",
+    	score       = "Minimum score (0 to 1)",
 	};
 }
 ```

--- a/models/RecaptchaService.cfc
+++ b/models/RecaptchaService.cfc
@@ -17,6 +17,11 @@ component singleton accessors="true"{
 	property name="publicKey" 	default="";
 
 	/**
+	* Minimum score
+        */
+	property name="score"		default="";
+
+	/**
 	 * Constructor
 	 *
 	 * @secretKey The google secret key
@@ -36,6 +41,7 @@ component singleton accessors="true"{
 	function onDIComplete(){
 		variables.secretKey = variables.config.secretKey;
 		variables.publicKey = variables.config.publicKey;
+		variables.score     = variables.config.score;
 	}
 
 	/**
@@ -49,7 +55,7 @@ component singleton accessors="true"{
 
 		var check = deserializeJSON( result.filecontent );
 
-		return check.success;
+		return ( check.score >= variables.score );
 	}
 
 	/**


### PR DESCRIPTION
The `isValid` function checks the field success in the Google API response. 

But this field is only says if the request was a valid reCAPTCHA token for your site:

https://developers.google.com/recaptcha/docs/v3#site_verify_response


To check the validation of the recaptcha, it must be checked the `score` field with come predefined score. 

This PR adds a score configuration settings and checks the response  `score` field. 